### PR TITLE
Allow each image load to individually fail

### DIFF
--- a/internal/game/image.go
+++ b/internal/game/image.go
@@ -25,18 +25,19 @@ var (
 // InitImages initialize game images
 func InitImages() {
 
-	shipImage, _, err = ebitenutil.NewImageFromFile("../../assets/player.png")
-	alienImage, _, err = ebitenutil.NewImageFromFile("../../assets/alien.png")
-	missileImage, _, err = ebitenutil.NewImageFromFile("../../assets/missile.png")
-	fusionImage, _, err = ebitenutil.NewImageFromFile("../../assets/fusion.png")
-	rcsl, _, err = ebitenutil.NewImageFromFile("../../assets/rcsl.png")
-	rcsr, _, err = ebitenutil.NewImageFromFile("../../assets/rcsr.png")
-	rcsfl, _, err = ebitenutil.NewImageFromFile("../../assets/rcsfl.png")
-	rcsfr, _, err = ebitenutil.NewImageFromFile("../../assets/rcsfr.png")
-	rcsbl, _, err = ebitenutil.NewImageFromFile("../../assets/rcsbl.png")
-	rcsbr, _, err = ebitenutil.NewImageFromFile("../../assets/rcsbr.png")
-	space, _, err = ebitenutil.NewImageFromFile("../../assets/space.png")
+	mustLoadImageFromFile(shipImage, "../../assets/player.png")
+	mustLoadImageFromFile(alienImage, "../../assets/alien.png")
+	mustLoadImageFromFile(missileImage, "../../assets/missile.png")
+	mustLoadImageFromFile(fusionImage, "../../assets/fusion.png")
+	mustLoadImageFromFile(rcsl, "../../assets/rcsl.png")
+	mustLoadImageFromFile(rcsr, "../../assets/rcsr.png")
+	mustLoadImageFromFile(rcsbl, "../../assets/rcsbl.png")
+	mustLoadImageFromFile(rcsbr, "../../assets/rcsbr.png")
+	mustLoadImageFromFile(space, "../../assets/space.png")
+}
 
+func mustLoadImageFromFile(img *ebiten.Image, imgPath string) {
+	img, _, err := ebitenutil.NewImageFromFile(imgPath)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
So at the moment when loading all of the asset images, the error response is not checked per image load, so even if one of the images is unable to load, for example if the first image cannot load, but the last image can, by the time the check is reached err will have been overridden to nil. This change is to ensure each specific image load failure is caught and fatals out at this point. If you really wanted to one way to handle this would be to just try and load each image, and compose all of the collective errors together, so in the output it is able to list each image that was unable to load. That could be a further improvement maybe? 🤷‍♂️